### PR TITLE
Add compatibility with amoc 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ EXPOSE 4000
 
 RUN mkdir /etc/service/amoc
 COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/docker/amoc.sh /etc/service/amoc/run
+COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/priv/vm.args /home/amoc/amoc_arsenal_xmpp/releases/${vsn}/vm.args
 COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/docker/run.sh /run.sh
 
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,6 @@ ARG vsn
 ARG amoc_arsenal_home=/home/amoc/amoc_arsenal_xmpp
 
 ENV EXEC_PATH ${amoc_arsenal_home}/bin/amoc_arsenal_xmpp
-ENV SYSCONFIG ${amoc_arsenal_home}/releases/${vsn}/sys.config
-ENV VMARGS ${amoc_arsenal_home}/releases/${vsn}/vm.args
 
 RUN useradd -ms /bin/bash amoc
 
@@ -43,8 +41,6 @@ EXPOSE 4000
 
 RUN mkdir /etc/service/amoc
 COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/docker/amoc.sh /etc/service/amoc/run
-COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/docker/config/vm.args /home/amoc/amoc_arsenal_xmpp/releases/${vsn}/vm.args
-COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/docker/config/sys.config.template /sys.config.template
 COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/docker/run.sh /run.sh
 
 CMD ["/run.sh"]

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
             {parse_transform, lager_transform}]}.
 
 {deps, [{escalus, {git, "https://github.com/esl/escalus.git", {ref, "5794d0a"}}},
-        {amoc, {git, "https://github.com/esl/amoc", {ref, "d756cff"}}}]}.
+        {amoc, {git, "https://github.com/esl/amoc", {ref, "b89a927"}}}]}.
 
 {xref_checks,[
               %% enable most checks, but avoid 'unused calls' which makes amoc-arsenal fail...

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"amoc">>,
   {git,"https://github.com/esl/amoc",
-       {ref,"d756cffebc7f157c5f337b7520c808b68c76b38e"}},
+       {ref,"b89a92770d04f0a48ce5a6c508bd033293a1fc03"}},
   0},
  {<<"base16">>,
   {git,"https://github.com/goj/base16.git",


### PR DESCRIPTION
This PR is suppose to make amoc-arsenal work with amoc 2.0.

I think that I will change amoc version in rebar.config to amoc 2.0.0 after its release.