### PR TITLE
Add phusion version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ RUN apt-get update && \
         clang \
         libexpat1-dev \
         wget \
+        gnupg \
         iproute2 && \
-    wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
-    dpkg -i erlang-solutions_1.0_all.deb && \
+    wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
+    dpkg -i erlang-solutions_2.0_all.deb && \
     apt-get update && \
     apt-get install -y esl-erlang=1:${otp_vsn}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage AS builder
+FROM phusion/baseimage:bionic-1.0.0 AS builder
 
 ARG otp_vsn=21.3.8.7-1
 
@@ -22,7 +22,7 @@ COPY . /amoc_arsenal_build
 RUN cd amoc_arsenal_build && \
     ./rebar3 release
 
-FROM phusion/baseimage
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER Erlang Solutions <mongoose-im@erlang-solutions.com>
 
 ARG vsn


### PR DESCRIPTION
Travis build was failing due to the reason: 
`manifest for phusion/baseimage:latest not found`

Using latest is not recommended and now not supported.
https://github.com/phusion/baseimage-docker/issues/562

The version was updated to bionic-1.0.0 which currently is the latest release. 
https://github.com/phusion/baseimage-docker/releases