### PR TITLE
Introduce helpers and scenarios for dynamic domains

### DIFF
--- a/src/helpers/amoc_xmpp.erl
+++ b/src/helpers/amoc_xmpp.erl
@@ -74,13 +74,13 @@ make_user(Id, Props) ->
 
 -spec default_user_spec(binary(), binary()) -> escalus_users:user_spec().
 default_user_spec(ProfileId, Password) ->
-    [ {username, ProfileId},
-      {server, <<"localhost">>},
-      {host, <<"127.0.0.1">>},
-      {password, Password},
-      {carbons, false},
-      {stream_management, false},
-      {resource, base64:encode(crypto:strong_rand_bytes(5))}].
+    [{username, ProfileId},
+     {server, <<"localhost">>},
+     {password, Password},
+     {carbons, false},
+     {stream_management, false},
+     {resource, base64:encode(crypto:strong_rand_bytes(5))}] ++
+        pick_server([[{host, "127.0.0.1"}]]).
 
 -spec send_request_and_get_response(
         escalus:client(), exml:element(), escalus_connection:stanza_pred(), amoc_metrics:name(), timeout()

--- a/src/helpers/amoc_xmpp.erl
+++ b/src/helpers/amoc_xmpp.erl
@@ -4,6 +4,7 @@
 -export([connect_or_exit/2]).
 -export([pick_server/1]).
 -export([send_request_and_get_response/5]).
+-export([bucket_neighbours/2]).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -99,3 +100,10 @@ send_request_and_get_response(Client, Req, Pred, TimeMetric, Timeout) ->
             amoc_metrics:update_time(TimeMetric, RecvTimestamp - SendTimestamp),
             Stanza
     end.
+
+%% Divide users into buckets of BucketSize and return all users from the bucket except Id
+-spec bucket_neighbours(amoc_scenario:user_id(), pos_integer()) -> [amoc_scenario:user_id()].
+bucket_neighbours(Id, BucketSize) ->
+    PositionInBucket = (Id - 1) rem BucketSize,
+    BucketStartId = Id - PositionInBucket,
+    lists:delete(Id, lists:seq(BucketStartId, BucketStartId + BucketSize - 1)).

--- a/src/helpers/amoc_xmpp.erl
+++ b/src/helpers/amoc_xmpp.erl
@@ -3,6 +3,7 @@
 -export([connect_or_exit/1]).
 -export([connect_or_exit/2]).
 -export([pick_server/1]).
+-export([make_user/2]).
 -export([send_request_and_get_response/5]).
 -export([bucket_neighbours/2]).
 

--- a/src/helpers/amoc_xmpp.erl
+++ b/src/helpers/amoc_xmpp.erl
@@ -102,7 +102,9 @@ send_request_and_get_response(Client, Req, Pred, TimeMetric, Timeout) ->
             Stanza
     end.
 
-%% Divide users into buckets of BucketSize and return all users from the bucket except Id
+%% @doc Divide users into buckets of BucketSize and return all users from the bucket except Id.
+%% When the total user number is divisible by BucketSize, it makes the total number of messages
+%% easy to predict and check.
 -spec bucket_neighbours(amoc_scenario:user_id(), pos_integer()) -> [amoc_scenario:user_id()].
 bucket_neighbours(Id, BucketSize) ->
     PositionInBucket = (Id - 1) rem BucketSize,

--- a/src/helpers/amoc_xmpp_mam.erl
+++ b/src/helpers/amoc_xmpp_mam.erl
@@ -1,0 +1,84 @@
+-module(amoc_xmpp_mam).
+
+-include_lib("exml/include/exml.hrl").
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-required_variable(
+   [#{name => max_items_per_lookup, default_value => 5, verification => ?V(nonnegative_integer),
+      description => "Maximum number of messages returned per MAM lookup"},
+    #{name => mam_lookup_timeout, default_value => 10, verification => ?V(positive_integer),
+      description => "Timeout for each MAM lookup request (in seconds)"}
+   ]).
+
+-export([init/0, get_mam_messages/2, received_handler_spec/1]).
+
+-spec init() -> ok.
+init() ->
+    amoc_xmpp_presence:init(),
+    amoc_metrics:init(counters, mam_lookups),
+    amoc_metrics:init(counters, mam_messages_received),
+    amoc_metrics:init(counters, timeouts),
+    amoc_metrics:init(times, mam_lookup_response_time),
+    ok.
+
+get_mam_messages(Client, Opts) ->
+    Req = mam_request(Opts),
+    Pred = fun(Stanza) -> escalus_pred:is_iq_result(Req, Stanza) end,
+    Metric = mam_lookup_response_time,
+    Timeout = cfg(mam_lookup_timeout),
+    amoc_metrics:update_counter(mam_lookups),
+    Response = amoc_xmpp:send_request_and_get_response(Client, Req, Pred, Metric, Timeout),
+    get_last_id(Response).
+
+mam_request(Opts) ->
+    Max = cfg(max_items_per_lookup),
+    SetChild = #xmlel{name = <<"set">>,
+                      attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/rsm">>}],
+                      children = [#xmlel{name = <<"max">>,
+                                         children = [#xmlcdata{content = integer_to_binary(Max)}]}
+                                 | after_elements(Opts)]},
+    Req = escalus_stanza:iq(<<"set">>,
+                            [#xmlel{name = <<"query">>,
+                                    attrs = [{<<"xmlns">>,  <<"urn:xmpp:mam:2">>}],
+                                    children = [SetChild]}]),
+    case Opts of
+        #{jid := Jid} -> escalus_stanza:to(Req, Jid);
+        #{} -> Req
+    end.
+
+after_elements(#{last_id := LastId}) when LastId =/= none ->
+    [#xmlel{name = <<"after">>, children = [#xmlcdata{content = LastId}]}];
+after_elements(#{}) -> [].
+
+%% Wrap around if the next result set would be incomplete
+get_last_id(Stanza) ->
+    [SetEl] = exml_query:paths(Stanza, [{element, <<"fin">>}, {element, <<"set">>}]),
+    [FirstIndex] = exml_query:paths(SetEl, [{element, <<"first">>}, {attr, <<"index">>}]),
+    [CountBin] = exml_query:paths(SetEl, [{element, <<"count">>}, cdata]),
+    Count = binary_to_integer(CountBin),
+    case binary_to_integer(FirstIndex) + 2*cfg(max_items_per_lookup) =< Count of
+        true -> exml_query:path(SetEl, [{element, <<"last">>}, cdata], none);
+        false -> none
+    end.
+
+received_handler_spec(Type) ->
+    [{fun(M) -> is_mam_archived_message(M, Type) end,
+      fun() -> amoc_metrics:update_counter(mam_messages_received) end}].
+
+is_mam_archived_message(#xmlel{name = <<"message">>} = Stanza, Type) ->
+    M = exml_query:path(Stanza, [{element, <<"result">>},
+                                 {element, <<"forwarded">>},
+                                 {element, <<"message">>}]),
+    BinType = atom_to_binary(Type),
+    escalus_pred:is_message(M) andalso escalus_pred:has_type(BinType, Stanza);
+is_mam_archived_message(_Stanza, _Type) ->
+    false.
+
+%% Config helpers
+
+cfg(Name) ->
+    convert(Name, amoc_config:get(Name)).
+
+convert(mam_lookup_timeout, V) -> timer:seconds(V);
+convert(_Name, V) -> V.

--- a/src/helpers/amoc_xmpp_mam.erl
+++ b/src/helpers/amoc_xmpp_mam.erl
@@ -71,7 +71,7 @@ is_mam_archived_message(#xmlel{name = <<"message">>} = Stanza, Type) ->
                                  {element, <<"forwarded">>},
                                  {element, <<"message">>}]),
     BinType = atom_to_binary(Type),
-    escalus_pred:is_message(M) andalso escalus_pred:has_type(BinType, Stanza);
+    escalus_pred:is_message(M) andalso escalus_pred:has_type(BinType, M);
 is_mam_archived_message(_Stanza, _Type) ->
     false.
 

--- a/src/helpers/amoc_xmpp_presence.erl
+++ b/src/helpers/amoc_xmpp_presence.erl
@@ -3,10 +3,14 @@
 -define(V(X), (fun amoc_config_validation:X/1)).
 
 -required_variable(
-   [#{name => wait_time_before_scenario, default_value => 60, verification => ?V(nonnegative_integer),
-      description => "Wait time before scenario after connecting (in seconds)"},
-    #{name => wait_time_after_scenario, default_value => 60, verification => ?V(nonnegative_integer),
-      description => "Wait time after scenario before disconnecting (in seconds)"}
+   [#{name => wait_time_after_presence_available,
+      default_value => 60,
+      verification => ?V(nonnegative_integer),
+      description => "Wait time after sending presence: available (in seconds)"},
+    #{name => wait_time_before_presence_unavailable,
+      default_value => 60,
+      verification => ?V(nonnegative_integer),
+      description => "Wait time before sending presence: unavailable (in seconds)"}
    ]).
 
 -export([init/0,
@@ -15,16 +19,19 @@
          sent_handler_spec/0,
          received_handler_spec/0]).
 
+-spec init() -> any().
 init() ->
     amoc_metrics:init(counters, presences_sent),
     amoc_metrics:init(counters, presences_received).
 
+-spec start(escalus:client()) -> any().
 start(Client) ->
     send_presence_available(Client),
-    escalus_connection:wait(Client, cfg(wait_time_before_scenario)).
+    escalus_connection:wait(Client, cfg(wait_time_after_presence_available)).
 
+-spec stop(escalus:client()) -> any().
 stop(Client) ->
-    escalus_connection:wait(Client, cfg(wait_time_after_scenario)),
+    escalus_connection:wait(Client, cfg(wait_time_before_presence_unavailable)),
     send_presence_unavailable(Client),
     escalus_connection:stop(Client).
 
@@ -42,10 +49,12 @@ send_presence_unavailable(Client) ->
 
 %% Stanza handlers
 
+-spec sent_handler_spec() -> [amoc_xmpp_handlers:handler_spec()].
 sent_handler_spec() ->
     [{fun escalus_pred:is_presence/1,
       fun() -> amoc_metrics:update_counter(presences_sent) end}].
 
+-spec received_handler_spec() -> [amoc_xmpp_handlers:handler_spec()].
 received_handler_spec() ->
     [{fun escalus_pred:is_presence/1,
       fun() -> amoc_metrics:update_counter(presences_received) end}].

--- a/src/helpers/amoc_xmpp_presence.erl
+++ b/src/helpers/amoc_xmpp_presence.erl
@@ -1,0 +1,56 @@
+-module(amoc_xmpp_presence).
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-required_variable(
+   [#{name => wait_time_before_scenario, default_value => 60, verification => ?V(nonnegative_integer),
+      description => "Wait time before scenario after connecting (in seconds)"},
+    #{name => wait_time_after_scenario, default_value => 60, verification => ?V(nonnegative_integer),
+      description => "Wait time after scenario before disconnecting (in seconds)"}
+   ]).
+
+-export([init/0,
+         start/1,
+         stop/1,
+         sent_handler_spec/0,
+         received_handler_spec/0]).
+
+init() ->
+    amoc_metrics:init(counters, presences_sent),
+    amoc_metrics:init(counters, presences_received).
+
+start(Client) ->
+    send_presence_available(Client),
+    escalus_connection:wait(Client, cfg(wait_time_before_scenario)).
+
+stop(Client) ->
+    escalus_connection:wait(Client, cfg(wait_time_after_scenario)),
+    send_presence_unavailable(Client),
+    escalus_connection:stop(Client).
+
+%% Stanza
+
+-spec send_presence_available(escalus:client()) -> ok.
+send_presence_available(Client) ->
+    Pres = escalus_stanza:presence(<<"available">>),
+    escalus_connection:send(Client, Pres).
+
+-spec send_presence_unavailable(escalus:client()) -> ok.
+send_presence_unavailable(Client) ->
+    Pres = escalus_stanza:presence(<<"unavailable">>),
+    escalus_connection:send(Client, Pres).
+
+%% Stanza handlers
+
+sent_handler_spec() ->
+    [{fun escalus_pred:is_presence/1,
+      fun() -> amoc_metrics:update_counter(presences_sent) end}].
+
+received_handler_spec() ->
+    [{fun escalus_pred:is_presence/1,
+      fun() -> amoc_metrics:update_counter(presences_received) end}].
+
+%% Config helpers
+
+cfg(Name) ->
+    timer:seconds(amoc_config:get(Name)).

--- a/src/helpers/dynamic_domains.erl
+++ b/src/helpers/dynamic_domains.erl
@@ -19,22 +19,31 @@
       description => "Port number of the REST API for dynamic domains"},
     #{name => host_type, default_value => <<"localhost">>, verification => ?V(binary),
       description => "Host type for the created domains"},
-    #{name => wait_time_for_domain_creation, default_value => 60, verification => ?V(nonnegative_integer),
+    #{name => wait_time_for_domain_creation, default_value => 60,
+      verification => ?V(nonnegative_integer),
       description => "Time to wait until the domain is created by the first user (in seconds)"}
    ]).
 
+-type connect_opts() :: #{create_domain => boolean()}.
+
+-spec init() -> any().
 init() ->
     amoc_metrics:init(counters, domain_creation_requests),
     amoc_metrics:init(times, domain_creation_time).
 
+-spec connect_or_exit(amoc_scenario:user_id(), escalus_users:user_spec()) ->
+          {ok, escalus_connection:client(), escalus_users:user_spec()}.
 connect_or_exit(Id, ExtraSpec) ->
     connect_or_exit(Id, ExtraSpec, #{}).
 
+-spec connect_or_exit(amoc_scenario:user_id(), escalus_users:user_spec(), connect_opts()) ->
+          {ok, escalus_connection:client(), escalus_users:user_spec()}.
 connect_or_exit(Id, ExtraSpec, Opts) ->
     Spec = amoc_xmpp:make_user(Id, [{server, dynamic_domains:domain_name(Id)} | ExtraSpec]),
     maybe_create_domain(Id, Spec, Opts),
     amoc_xmpp:connect_or_exit(Spec).
 
+-spec maybe_create_domain(amoc_scenario:user_id(), escalus_users:user_spec(), connect_opts()) -> ok.
 maybe_create_domain(UserId, UserSpec, Opts) ->
     case should_create_domain(UserId, Opts) of
         true ->
@@ -48,15 +57,18 @@ maybe_create_domain(UserId, UserSpec, Opts) ->
     end,
     timer:sleep(cfg(wait_time_for_domain_creation)).
 
+-spec should_create_domain(amoc_scenario:user_id(), connect_opts()) -> boolean().
 should_create_domain(_UserId, #{create_domain := Value}) -> Value;
 should_create_domain(UserId, #{}) -> is_first_user_in_domain(UserId).
 
+-spec is_first_user_in_domain(amoc_scenario:user_id()) -> boolean().
 is_first_user_in_domain(UserId) ->
     BucketSize = cfg(domain_bucket_size),
     PositionInBucket = (UserId - 1) rem BucketSize,
     BucketIdFromZero = (UserId - 1) div BucketSize,
     PositionInBucket == 0 andalso BucketIdFromZero < cfg(domain_count).
 
+-spec create_domain(binary(), binary()) -> ok.
 create_domain(Host, Domain) ->
     {ok, Conn} = gun:open(binary_to_list(Host), cfg(rest_port)),
     Path = <<"/api/domains/", Domain/binary>>,
@@ -65,11 +77,13 @@ create_domain(Host, Domain) ->
     {response, fin, 204, _} = gun:await(Conn, Stream),
     gun:close(Conn).
 
+-spec domain_name(amoc_scenario:user_id()) -> binary().
 domain_name(UserId) ->
     Prefix = cfg(domain_prefix),
     BinId = integer_to_binary(domain_id(UserId)),
     <<Prefix/binary, BinId/binary>>.
 
+-spec domain_id(amoc_scenario:user_id()) -> pos_integer().
 domain_id(UserId) ->
     BucketSize = cfg(domain_bucket_size),
     BucketIdFromZero = (UserId - 1) div BucketSize,

--- a/src/helpers/dynamic_domains.erl
+++ b/src/helpers/dynamic_domains.erl
@@ -1,0 +1,68 @@
+-module(dynamic_domains).
+
+-export([connect_or_exit/2,
+         domain_name/1,
+         domain_id/1]).
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-required_variable(
+   [#{name => domain_count, default_value => 10000, verification => ?V(positive_integer),
+      description => "Number of dynamic domains"},
+    #{name => domain_bucket_size, default_value => 1, verification => ?V(positive_integer),
+      description => "Number of consecutive users belonging to the same domain"},
+    #{name => domain_prefix, default_value => <<"test-domain-">>, verification => ?V(binary),
+      description => "Prefix of the dynamic domain names"},
+    #{name => rest_port, default_value => 8088, verification => ?V(positive_integer),
+      description => "Port number of the REST API for dynamic domains"},
+    #{name => host_type, default_value => <<"localhost">>, verification => ?V(binary),
+      description => "Host type for the created domains"},
+    #{name => wait_time_for_domain_creation, default_value => 60, verification => ?V(nonnegative_integer),
+      description => "Time to wait until the domain is created by the first user (in seconds)"}
+   ]).
+
+connect_or_exit(Id, ExtraSpec) ->
+    Spec = amoc_xmpp:make_user(Id, [{server, dynamic_domains:domain_name(Id)} | ExtraSpec]),
+    maybe_create_domain(Id, Spec),
+    amoc_xmpp:connect_or_exit(Spec).
+
+maybe_create_domain(UserId, UserSpec) ->
+    case is_first_user_in_domain(UserId) of
+        true ->
+            Host = proplists:get_value(host, UserSpec),
+            Domain = proplists:get_value(server, UserSpec),
+            create_domain(Host, Domain);
+        false ->
+            not_needed
+    end,
+    timer:sleep(cfg(wait_time_for_domain_creation)).
+
+is_first_user_in_domain(UserId) ->
+    BucketSize = cfg(domain_bucket_size),
+    PositionInBucket = (UserId - 1) rem BucketSize,
+    BucketIdFromZero = (UserId - 1) div BucketSize,
+    PositionInBucket == 0 andalso BucketIdFromZero < cfg(domain_count).
+
+create_domain(Host, Domain) ->
+    {ok, Conn} = gun:open(binary_to_list(Host), cfg(rest_port)),
+    Path = <<"/api/domains/", Domain/binary>>,
+    Body = <<"{\"host_type\": \"", (cfg(host_type))/binary, "\"}">>,
+    Stream = gun:put(Conn, Path, [{<<"content-type">>, <<"application/json">>}], Body),
+    {response, fin, 204, _} = gun:await(Conn, Stream),
+    gun:close(Conn).
+
+domain_name(UserId) ->
+    Prefix = cfg(domain_prefix),
+    BinId = integer_to_binary(domain_id(UserId)),
+    <<Prefix/binary, BinId/binary>>.
+
+domain_id(UserId) ->
+    BucketSize = cfg(domain_bucket_size),
+    BucketIdFromZero = (UserId - 1) div BucketSize,
+    BucketIdFromZero rem cfg(domain_count) + 1.
+
+cfg(Name) ->
+    convert(Name, amoc_config:get(Name)).
+
+convert(wait_time_for_domain_creation, V) -> timer:seconds(V);
+convert(_Name, V) -> V.

--- a/src/helpers/timetable.erl
+++ b/src/helpers/timetable.erl
@@ -1,0 +1,35 @@
+%% Minimalistic module for performing time-ordered actions in load tests without an event loop
+
+-module(timetable).
+
+-export([new/3, do/3, do/4, merge/1]).
+
+new(Event, Count, Interval) ->
+    Offset = rand:uniform(Interval),
+    [{Interval * I + Offset, Event} || I <- lists:seq(0, Count - 1)].
+
+%% @doc Stateless execution
+do(Client, F, TimeTable) ->
+    do(Client, fun(_, Event, _) ->
+                       F(Client, Event),
+                       no_state
+               end, TimeTable, no_state).
+
+%% @doc Stateful execution
+do(Client, F, TimeTable, State) ->
+    step(Client, F, TimeTable, State, current_time()).
+
+step(Client, F, [{Time, Event} | TimeTable], State, StartTime) ->
+    Elapsed = current_time() - StartTime,
+    TimeDiff = max(0, Time - Elapsed),
+    escalus_connection:wait(Client, TimeDiff),
+    NewState = F(Client, Event, State),
+    step(Client, F, TimeTable, NewState, StartTime);
+step(_Client, _F, [], _State, _StartTime) ->
+    ok.
+
+merge(Tables) ->
+    lists:merge(Tables).
+
+current_time() ->
+    erlang:system_time(millisecond).

--- a/src/helpers/timetable.erl
+++ b/src/helpers/timetable.erl
@@ -4,30 +4,47 @@
 
 -export([new/3, do/3, do/4, merge/1]).
 
+-type time_diff() :: non_neg_integer(). %% milliseconds
+-type timetable(Event) :: [{time_diff(), Event}].
+-type executor(Event) :: fun((escalus:client(), Event) -> any()).
+-type executor(Event, State) :: fun((escalus:client(), Event, State) -> State).
+
+-export_type([timetable/1]).
+
+%% @doc Creates a new timetable with Event scheduled every Interval (ms)
+%%      Start time is a random Offset where 0 =< Offset =< Interval
+-spec new(Event, non_neg_integer(), time_diff()) -> timetable(Event).
 new(Event, Count, Interval) ->
-    Offset = rand:uniform(Interval),
+    Offset = rand:uniform(Interval + 1) - 1,
     [{Interval * I + Offset, Event} || I <- lists:seq(0, Count - 1)].
 
-%% @doc Stateless execution
+%% @doc Executes F for each {Time, Event} from TimeTable as soon as Time (ms) passed
+%%      AND previous executions finished.
+-spec do(escalus:client(), executor(Event), timetable(Event)) -> ok.
 do(Client, F, TimeTable) ->
-    do(Client, fun(_, Event, _) ->
+    do(Client, fun(_, Event, no_state) ->
                        F(Client, Event),
                        no_state
-               end, TimeTable, no_state).
+               end, TimeTable, no_state),
+    ok.
 
-%% @doc Stateful execution
+%% @doc Like do/3, but passes State through the executions of F.
+-spec do(escalus:client(), executor(Event, State), timetable(Event), State) -> State.
 do(Client, F, TimeTable, State) ->
     step(Client, F, TimeTable, State, current_time()).
 
+-spec step(escalus:client(), executor(Event, State), timetable(Event), State, integer()) -> State.
 step(Client, F, [{Time, Event} | TimeTable], State, StartTime) ->
     Elapsed = current_time() - StartTime,
     TimeDiff = max(0, Time - Elapsed),
     escalus_connection:wait(Client, TimeDiff),
     NewState = F(Client, Event, State),
     step(Client, F, TimeTable, NewState, StartTime);
-step(_Client, _F, [], _State, _StartTime) ->
-    ok.
+step(_Client, _F, [], State, _StartTime) ->
+    State.
 
+%% @doc Merges Tables preserving the time order
+-spec merge([timetable(Event)]) -> timetable(Event).
 merge(Tables) ->
     lists:merge(Tables).
 

--- a/src/scenarios/dynamic_domains_mam_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_lookup.erl
@@ -33,15 +33,16 @@ start(MyId) ->
     do(MyId, Client),
     amoc_xmpp_presence:stop(Client).
 
--record(state, {last_mam_id = none}).
+-record(state, {last_mam_id = none :: amoc_xmpp_mam:last_id()}).
 
 -spec do(amoc_scenario:user_id(), escalus:client()) -> any().
 do(_MyId, Client) ->
     TimeTable = timetable:new(mam_lookup, cfg(lookup_count), cfg(lookup_interval)),
     timetable:do(Client, fun send_stanza/3, TimeTable, #state{}).
 
+-spec send_stanza(escalus:client(), mam_lookup, #state{}) -> #state{}.
 send_stanza(Client, mam_lookup, State = #state{last_mam_id = Id}) ->
-    NewId = amoc_xmpp_mam:get_mam_messages(Client, #{last_id => Id}),
+    NewId = amoc_xmpp_mam:lookup(Client, #{last_id => Id}),
     State#state{last_mam_id = NewId}.
 
 %% Stanza handlers

--- a/src/scenarios/dynamic_domains_mam_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_lookup.erl
@@ -1,0 +1,91 @@
+-module(dynamic_domains_mam_lookup).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("exml/include/exml.hrl").
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-required_variable(
+   [#{name => lookup_count, default_value => 20, verification => ?V(positive_integer),
+      description => "Number of lookups performed by each user"},
+    #{name => lookup_interval, default_value => 10, verification => ?V(nonnegative_integer),
+      description => "Interval (in seconds) between lookups"}
+   ]).
+
+-behaviour(amoc_scenario).
+
+-export([init/0, start/1]).
+
+-spec init() -> ok.
+init() ->
+    ?LOG_INFO("init metrics"),
+    amoc_xmpp_presence:init(),
+    amoc_metrics:init(counters, mam_messages_received),
+    amoc_metrics:init(counters, mam_lookups),
+    amoc_metrics:init(counters, timeouts),
+    amoc_metrics:init(times, mam_lookup_response_time),
+    ok.
+
+%% User helpers
+
+-spec start(amoc_scenario:user_id()) -> any().
+start(MyId) ->
+    Spec = amoc_xmpp_handlers:make_props(received_handler_spec(), sent_handler_spec()),
+    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
+    amoc_xmpp_presence:start(Client),
+    do(MyId, Client),
+    amoc_xmpp_presence:stop(Client).
+
+-record(state, {last_mam_id = none}).
+
+-spec do(amoc_scenario:user_id(), escalus:client()) -> any().
+do(_MyId, Client) ->
+    TimeTable = timetable:new(mam_lookup, cfg(lookup_count), cfg(lookup_interval)),
+    timetable:do(Client, fun send_stanza/3, TimeTable, #state{}).
+
+send_stanza(Client, mam_lookup, State = #state{last_mam_id = Id}) ->
+    NewId = get_mam_messages(Client, Id),
+    State#state{last_mam_id = NewId}.
+
+%% MAM requests
+
+get_mam_messages(Client, LastId) ->
+    SetChild = #xmlel{name = <<"set">>,
+                      attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/rsm">>}],
+                      children = [#xmlel{name = <<"max">>,
+                                         children = [#xmlcdata{content = <<"5">>}]}
+                                 | after_elements(LastId)]},
+    Req = escalus_stanza:iq(<<"set">>,
+                            [#xmlel{name = <<"query">>,
+                                    attrs = [{<<"xmlns">>,  <<"urn:xmpp:mam:2">>}],
+                                    children = [SetChild]}]),
+    Pred = fun(Stanza) -> escalus_pred:is_iq_result(Req, Stanza) end,
+    Metric = mam_lookup_response_time,
+    Timeout = timer:seconds(10),
+    amoc_metrics:update_counter(mam_lookups),
+    Response = amoc_xmpp:send_request_and_get_response(Client, Req, Pred, Metric, Timeout),
+    get_last_id(Response).
+
+after_elements(none) -> [];
+after_elements(Last) -> [#xmlel{name = <<"after">>, children = [#xmlcdata{content = Last}]}].
+
+get_last_id(Stanza) ->
+    exml_query:paths(Stanza, [{element, <<"fin">>}, {element, <<"set">>}, {element, <<"last">>}, cdata]).
+
+%% Stanza handlers
+
+sent_handler_spec() ->
+    amoc_xmpp_presence:sent_handler_spec().
+
+received_handler_spec() ->
+    [{fun(Stanza) -> escalus_pred:is_mam_archived_message(<<"hello">>, Stanza) end,
+      fun() -> amoc_metrics:update_counter(mam_messages_received) end} |
+     amoc_xmpp_presence:received_handler_spec()].
+
+%% Config helpers
+
+cfg(Name) ->
+    convert(Name, amoc_config:get(Name)).
+
+convert(lookup_interval, V) -> timer:seconds(V);
+convert(_Name, V) -> V.

--- a/src/scenarios/dynamic_domains_mam_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_lookup.erl
@@ -1,12 +1,11 @@
 -module(dynamic_domains_mam_lookup).
 
 -include_lib("kernel/include/logger.hrl").
--include_lib("exml/include/exml.hrl").
 
 -define(V(X), (fun amoc_config_validation:X/1)).
 
 -required_variable(
-   [#{name => lookup_count, default_value => 20, verification => ?V(positive_integer),
+   [#{name => lookup_count, default_value => 60, verification => ?V(positive_integer),
       description => "Number of lookups performed by each user"},
     #{name => lookup_interval, default_value => 10, verification => ?V(nonnegative_integer),
       description => "Interval (in seconds) between lookups"}
@@ -20,10 +19,7 @@
 init() ->
     ?LOG_INFO("init metrics"),
     amoc_xmpp_presence:init(),
-    amoc_metrics:init(counters, mam_messages_received),
-    amoc_metrics:init(counters, mam_lookups),
-    amoc_metrics:init(counters, timeouts),
-    amoc_metrics:init(times, mam_lookup_response_time),
+    amoc_xmpp_mam:init(),
     ok.
 
 %% User helpers
@@ -44,33 +40,8 @@ do(_MyId, Client) ->
     timetable:do(Client, fun send_stanza/3, TimeTable, #state{}).
 
 send_stanza(Client, mam_lookup, State = #state{last_mam_id = Id}) ->
-    NewId = get_mam_messages(Client, Id),
+    NewId = amoc_xmpp_mam:get_mam_messages(Client, #{last_id => Id}),
     State#state{last_mam_id = NewId}.
-
-%% MAM requests
-
-get_mam_messages(Client, LastId) ->
-    SetChild = #xmlel{name = <<"set">>,
-                      attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/rsm">>}],
-                      children = [#xmlel{name = <<"max">>,
-                                         children = [#xmlcdata{content = <<"5">>}]}
-                                 | after_elements(LastId)]},
-    Req = escalus_stanza:iq(<<"set">>,
-                            [#xmlel{name = <<"query">>,
-                                    attrs = [{<<"xmlns">>,  <<"urn:xmpp:mam:2">>}],
-                                    children = [SetChild]}]),
-    Pred = fun(Stanza) -> escalus_pred:is_iq_result(Req, Stanza) end,
-    Metric = mam_lookup_response_time,
-    Timeout = timer:seconds(10),
-    amoc_metrics:update_counter(mam_lookups),
-    Response = amoc_xmpp:send_request_and_get_response(Client, Req, Pred, Metric, Timeout),
-    get_last_id(Response).
-
-after_elements(none) -> [];
-after_elements(Last) -> [#xmlel{name = <<"after">>, children = [#xmlcdata{content = Last}]}].
-
-get_last_id(Stanza) ->
-    exml_query:paths(Stanza, [{element, <<"fin">>}, {element, <<"set">>}, {element, <<"last">>}, cdata]).
 
 %% Stanza handlers
 
@@ -78,9 +49,7 @@ sent_handler_spec() ->
     amoc_xmpp_presence:sent_handler_spec().
 
 received_handler_spec() ->
-    [{fun(Stanza) -> escalus_pred:is_mam_archived_message(<<"hello">>, Stanza) end,
-      fun() -> amoc_metrics:update_counter(mam_messages_received) end} |
-     amoc_xmpp_presence:received_handler_spec()].
+    amoc_xmpp_mam:received_handler_spec(chat) ++ amoc_xmpp_presence:received_handler_spec().
 
 %% Config helpers
 

--- a/src/scenarios/dynamic_domains_mam_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_lookup.erl
@@ -18,6 +18,7 @@
 -spec init() -> ok.
 init() ->
     ?LOG_INFO("init metrics"),
+    dynamic_domains:init(),
     amoc_xmpp_presence:init(),
     amoc_xmpp_mam:init(),
     ok.

--- a/src/scenarios/dynamic_domains_mam_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_lookup.erl
@@ -28,7 +28,7 @@ init() ->
 -spec start(amoc_scenario:user_id()) -> any().
 start(MyId) ->
     Spec = amoc_xmpp_handlers:make_props(received_handler_spec(), sent_handler_spec()),
-    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
+    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec, #{create_domain => false}),
     amoc_xmpp_presence:start(Client),
     do(MyId, Client),
     amoc_xmpp_presence:stop(Client).

--- a/src/scenarios/dynamic_domains_mam_muc_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_muc_lookup.erl
@@ -1,14 +1,11 @@
 -module(dynamic_domains_mam_muc_lookup).
 
 -include_lib("kernel/include/logger.hrl").
--include_lib("exml/include/exml.hrl").
 
 -define(V(X), (fun amoc_config_validation:X/1)).
 
 -required_variable(
-   [#{name => max_items_per_lookup, default_value => 5, verification => ?V(nonnegative_integer),
-      description => "Maximum number of messages returned per lookup"},
-    #{name => lookups_per_room, default_value => 36, verification => ?V(nonnegative_integer),
+   [#{name => lookups_per_room, default_value => 60, verification => ?V(nonnegative_integer),
       description => "Number of MAM lookups per room"},
     #{name => room_lookup_interval, default_value => 10, verification => ?V(nonnegative_integer),
       description => "Interval (in seconds) between lookups for each room"}
@@ -22,10 +19,7 @@
 init() ->
     ?LOG_INFO("init metrics"),
     amoc_xmpp_presence:init(),
-    amoc_metrics:init(counters, mam_messages_received),
-    amoc_metrics:init(counters, mam_lookups),
-    amoc_metrics:init(counters, timeouts),
-    amoc_metrics:init(times, mam_lookup_response_time),
+    amoc_xmpp_mam:init(),
     ok.
 
 -record(state, {last_mam_ids = #{}}).
@@ -53,43 +47,9 @@ room_lookup_timetable(MyId, RoomId) ->
                   cfg(lookups_per_room), cfg(room_lookup_interval)).
 
 send_stanza(Client, {mam_lookup, RoomJid}, State = #state{last_mam_ids = Ids}) ->
-    Id = maps:get(RoomJid, Ids, undefined),
-    NewId = get_mam_messages(Client, RoomJid, Id),
+    Id = maps:get(RoomJid, Ids, none),
+    NewId = amoc_xmpp_mam:get_mam_messages(Client, #{last_id => Id, jid => RoomJid}),
     State#state{last_mam_ids = Ids#{RoomJid => NewId}}.
-
-%% MAM requests
-
-get_mam_messages(Client, RoomJid, LastId) ->
-    Max = cfg(max_items_per_lookup),
-    SetChild = #xmlel{name = <<"set">>,
-                      attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/rsm">>}],
-                      children = [#xmlel{name = <<"max">>,
-                                         children = [#xmlcdata{content = integer_to_binary(Max)}]}
-                                 | after_elements(LastId)]},
-    Req0 = escalus_stanza:iq(<<"set">>,
-                            [#xmlel{name = <<"query">>,
-                                    attrs = [{<<"xmlns">>,  <<"urn:xmpp:mam:2">>}],
-                                    children = [SetChild]}]),
-    Req = escalus_stanza:to(Req0, RoomJid),
-    Pred = fun(Stanza) -> escalus_pred:is_iq_result(Req, Stanza) end,
-    Metric = mam_lookup_response_time,
-    Timeout = timer:seconds(10),
-    Response = amoc_xmpp:send_request_and_get_response(Client, Req, Pred, Metric, Timeout),
-    get_last_id(Response).
-
-after_elements(undefined) -> [];
-after_elements(Last) -> [#xmlel{name = <<"after">>, children = [#xmlcdata{content = Last}]}].
-
-%% Wrap around if the next result set would be incomplete
-get_last_id(Stanza) ->
-    [SetEl] = exml_query:paths(Stanza, [{element, <<"fin">>}, {element, <<"set">>}]),
-    [FirstIndex] = exml_query:paths(SetEl, [{element, <<"first">>}, {attr, <<"index">>}]),
-    [CountBin] = exml_query:paths(SetEl, [{element, <<"count">>}, cdata]),
-    Count = binary_to_integer(CountBin),
-    case binary_to_integer(FirstIndex) + 2*cfg(max_items_per_lookup) =< Count of
-        true -> exml_query:path(SetEl, [{element, <<"last">>}, cdata]);
-        false -> undefined
-    end.
 
 %% Room helpers
 
@@ -108,15 +68,7 @@ sent_handler_spec() ->
     amoc_xmpp_presence:sent_handler_spec().
 
 received_handler_spec() ->
-    [{fun is_mam_archived_message/1,
-      fun() -> amoc_metrics:update_counter(mam_messages_received) end} |
-     amoc_xmpp_presence:received_handler_spec()].
-
-is_mam_archived_message(#xmlel{} = Stanza) ->
-    M = exml_query:path(Stanza, [{element, <<"result">>},
-                                 {element, <<"forwarded">>},
-                                 {element, <<"message">>}]),
-    escalus_pred:is_groupchat_message(M).
+    amoc_xmpp_mam:received_handler_spec(groupchat) ++ amoc_xmpp_presence:received_handler_spec().
 
 %% Config helpers
 

--- a/src/scenarios/dynamic_domains_mam_muc_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_muc_lookup.erl
@@ -18,6 +18,7 @@
 -spec init() -> ok.
 init() ->
     ?LOG_INFO("init metrics"),
+    dynamic_domains:init(),
     amoc_xmpp_presence:init(),
     amoc_xmpp_mam:init(),
     ok.

--- a/src/scenarios/dynamic_domains_mam_muc_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_muc_lookup.erl
@@ -1,0 +1,127 @@
+-module(dynamic_domains_mam_muc_lookup).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("exml/include/exml.hrl").
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-required_variable(
+   [#{name => max_items_per_lookup, default_value => 5, verification => ?V(nonnegative_integer),
+      description => "Maximum number of messages returned per lookup"},
+    #{name => lookups_per_room, default_value => 36, verification => ?V(nonnegative_integer),
+      description => "Number of MAM lookups per room"},
+    #{name => room_lookup_interval, default_value => 10, verification => ?V(nonnegative_integer),
+      description => "Interval (in seconds) between lookups for each room"}
+   ]).
+
+-behaviour(amoc_scenario).
+
+-export([init/0, start/1]).
+
+-spec init() -> ok.
+init() ->
+    ?LOG_INFO("init metrics"),
+    amoc_xmpp_presence:init(),
+    amoc_metrics:init(counters, mam_messages_received),
+    amoc_metrics:init(counters, mam_lookups),
+    amoc_metrics:init(counters, timeouts),
+    amoc_metrics:init(times, mam_lookup_response_time),
+    ok.
+
+-record(state, {last_mam_ids = #{}}).
+
+-spec start(amoc_scenario:user_id()) -> any().
+start(MyId) ->
+    Spec = amoc_xmpp_handlers:make_props(received_handler_spec(), sent_handler_spec()),
+    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
+    amoc_xmpp_presence:start(Client),
+    do(MyId, Client),
+    amoc_xmpp_presence:stop(Client).
+
+-spec do(amoc_scenario:user_id(), escalus:client()) -> any().
+do(MyId, Client) ->
+    RoomIds = amoc_xmpp_muc:rooms_to_create(MyId, cfg(rooms_per_user), cfg(users_per_room)),
+    TimeTable = lookup_timetable(MyId, RoomIds),
+    timetable:do(Client, fun send_stanza/3, TimeTable, #state{}).
+
+lookup_timetable(MyId, RoomIds) ->
+    timetable:merge([room_lookup_timetable(MyId, RoomId) || RoomId <- RoomIds]).
+
+room_lookup_timetable(MyId, RoomId) ->
+    RoomJid = room_jid(RoomId, dynamic_domains:domain_name(MyId)),
+    timetable:new({mam_lookup, RoomJid},
+                  cfg(lookups_per_room), cfg(room_lookup_interval)).
+
+send_stanza(Client, {mam_lookup, RoomJid}, State = #state{last_mam_ids = Ids}) ->
+    Id = maps:get(RoomJid, Ids, undefined),
+    NewId = get_mam_messages(Client, RoomJid, Id),
+    State#state{last_mam_ids = Ids#{RoomJid => NewId}}.
+
+%% MAM requests
+
+get_mam_messages(Client, RoomJid, LastId) ->
+    Max = cfg(max_items_per_lookup),
+    SetChild = #xmlel{name = <<"set">>,
+                      attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/rsm">>}],
+                      children = [#xmlel{name = <<"max">>,
+                                         children = [#xmlcdata{content = integer_to_binary(Max)}]}
+                                 | after_elements(LastId)]},
+    Req0 = escalus_stanza:iq(<<"set">>,
+                            [#xmlel{name = <<"query">>,
+                                    attrs = [{<<"xmlns">>,  <<"urn:xmpp:mam:2">>}],
+                                    children = [SetChild]}]),
+    Req = escalus_stanza:to(Req0, RoomJid),
+    Pred = fun(Stanza) -> escalus_pred:is_iq_result(Req, Stanza) end,
+    Metric = mam_lookup_response_time,
+    Timeout = timer:seconds(10),
+    Response = amoc_xmpp:send_request_and_get_response(Client, Req, Pred, Metric, Timeout),
+    get_last_id(Response).
+
+after_elements(undefined) -> [];
+after_elements(Last) -> [#xmlel{name = <<"after">>, children = [#xmlcdata{content = Last}]}].
+
+%% Wrap around if the next result set would be incomplete
+get_last_id(Stanza) ->
+    [SetEl] = exml_query:paths(Stanza, [{element, <<"fin">>}, {element, <<"set">>}]),
+    [FirstIndex] = exml_query:paths(SetEl, [{element, <<"first">>}, {attr, <<"index">>}]),
+    [CountBin] = exml_query:paths(SetEl, [{element, <<"count">>}, cdata]),
+    Count = binary_to_integer(CountBin),
+    case binary_to_integer(FirstIndex) + 2*cfg(max_items_per_lookup) =< Count of
+        true -> exml_query:path(SetEl, [{element, <<"last">>}, cdata]);
+        false -> undefined
+    end.
+
+%% Room helpers
+
+room_jid(RoomId, Domain) ->
+    <<(room_name(RoomId))/binary, $@, (muc_host(Domain))/binary>>.
+
+room_name(RoomId) ->
+    <<"room_", (integer_to_binary(RoomId))/binary>>.
+
+muc_host(Domain) ->
+    <<"muclight.", Domain/binary>>.
+
+%% Stanza handlers
+
+sent_handler_spec() ->
+    amoc_xmpp_presence:sent_handler_spec().
+
+received_handler_spec() ->
+    [{fun is_mam_archived_message/1,
+      fun() -> amoc_metrics:update_counter(mam_messages_received) end} |
+     amoc_xmpp_presence:received_handler_spec()].
+
+is_mam_archived_message(#xmlel{} = Stanza) ->
+    M = exml_query:path(Stanza, [{element, <<"result">>},
+                                 {element, <<"forwarded">>},
+                                 {element, <<"message">>}]),
+    escalus_pred:is_groupchat_message(M).
+
+%% Config helpers
+
+cfg(Name) ->
+    convert(Name, amoc_config:get(Name)).
+
+convert(room_lookup_interval, V) -> timer:seconds(V);
+convert(_Name, V) -> V.

--- a/src/scenarios/dynamic_domains_mam_muc_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_muc_lookup.erl
@@ -28,7 +28,7 @@ init() ->
 -spec start(amoc_scenario:user_id()) -> any().
 start(MyId) ->
     Spec = amoc_xmpp_handlers:make_props(received_handler_spec(), sent_handler_spec()),
-    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
+    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec, #{create_domain => false}),
     amoc_xmpp_presence:start(Client),
     do(MyId, Client),
     amoc_xmpp_presence:stop(Client).

--- a/src/scenarios/dynamic_domains_muc_light.erl
+++ b/src/scenarios/dynamic_domains_muc_light.erl
@@ -1,0 +1,168 @@
+-module(dynamic_domains_muc_light).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("exml/include/exml.hrl").
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-required_variable(
+   [#{name => messages_sent_per_room, default_value => 180, verification => ?V(nonnegative_integer),
+      description => "Number of messages sent per room"},
+    #{name => room_creation_interval, default_value => 20, verification => ?V(nonnegative_integer),
+      description => "Delay between creating consecutive rooms (in seconds)"},
+    #{name => room_message_interval, default_value => 10, verification => ?V(nonnegative_integer),
+      description => "Interval (in seconds) between sending consecutive messages to each room"},
+    #{name => delay_before_sending_messages, default_value => 60, verification => ?V(nonnegative_integer),
+      description => "Delay between creating the last room and sending messages (in seconds)"}
+   ]).
+
+-behaviour(amoc_scenario).
+
+-export([init/0, start/1]).
+
+-spec init() -> ok.
+init() ->
+    ?LOG_INFO("init metrics"),
+    amoc_xmpp_presence:init(),
+    amoc_metrics:init(counters, muc_rooms_created),
+    amoc_metrics:init(counters, muc_occupants),
+    amoc_metrics:init(counters, muc_messages_sent),
+    amoc_metrics:init(counters, muc_messages_received),
+    amoc_metrics:init(counters, muc_notifications_received),
+    amoc_metrics:init(times, room_creation_response_time),
+    amoc_metrics:init(times, message_ttd),
+    ok.
+
+-spec start(amoc_scenario:user_id()) -> any().
+start(MyId) ->
+    Spec = amoc_xmpp_handlers:make_props(received_handler_spec(), sent_handler_spec()),
+    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
+    amoc_xmpp_presence:start(Client),
+    do(MyId, Client),
+    amoc_xmpp_presence:stop(Client).
+
+-spec do(amoc_scenario:user_id(), escalus:client()) -> any().
+do(MyId, Client) ->
+    MyRooms = amoc_xmpp_muc:rooms_to_create(MyId),
+    create_rooms(Client, MyId, MyRooms),
+    escalus_connection:wait(Client, cfg(delay_before_sending_messages)),
+    send_messages(Client, MyId, MyRooms).
+
+create_rooms(Client, MyId, MyRooms) ->
+    TimeTable = timetable:new(create_room, length(MyRooms), cfg(room_creation_interval)),
+    timetable:do(Client, fun(_, create_room, [RoomId | Rest]) ->
+                                 create_room(Client, MyId, RoomId),
+                                 Rest
+                         end, TimeTable, MyRooms).
+
+send_messages(Client, MyId, MyRooms) ->
+    TimeTable = message_timetable(MyId, MyRooms),
+    timetable:do(Client, fun send_stanza/2, TimeTable).
+
+message_timetable(MyId, RoomIdsToSend) ->
+    timetable:merge([room_message_timetable(MyId, RoomId) || RoomId <- RoomIdsToSend]).
+
+room_message_timetable(MyId, RoomId) ->
+    RoomJid = room_jid(RoomId, dynamic_domains:domain_name(MyId)),
+    timetable:new({groupchat, RoomJid},
+                  cfg(messages_sent_per_room), cfg(room_message_interval)).
+
+%% Room creation
+
+create_room(Client, MyId, RoomId) ->
+    MemberIds = amoc_xmpp_muc:room_members(MyId),
+    MemberJids = [make_jid(MemberId) || MemberId <- MemberIds],
+    RoomJid = room_jid(RoomId, dynamic_domains:domain_name(MyId)),
+    Req = stanza_create_room(room_name(RoomId), RoomJid, MemberJids),
+    Pred = fun(Stanza) -> escalus_pred:is_iq_result(Req, Stanza) end,
+    TimeMetric = room_creation_response_time,
+    amoc_xmpp:send_request_and_get_response(Client, Req, Pred, TimeMetric, 10000),
+    %% TODO check response
+    amoc_metrics:update_counter(muc_rooms_created).
+
+stanza_create_room(RoomName, RoomJid, MemberJids) ->
+    ConfigFields = [kv_el(<<"roomname">>, RoomName)],
+    ConfigElement = #xmlel{name = <<"configuration">>, children = ConfigFields},
+    UserFields = [user_element(Jid, <<"member">>) || Jid <- MemberJids],
+    OccupantsElement = #xmlel{name = <<"occupants">>, children = UserFields},
+    escalus_stanza:to(escalus_stanza:iq_set(ns(muc_light_create), [ConfigElement, OccupantsElement]),
+                      RoomJid).
+
+user_element(Jid, Aff) ->
+    #xmlel{name = <<"user">>,
+           attrs = [{<<"affiliation">>, Aff}],
+           children = [#xmlcdata{content = Jid}]}.
+
+kv_el(K, V) ->
+    #xmlel{name = K,
+           children = [#xmlcdata{content = V}]}.
+
+%% Groupchat messages
+
+send_stanza(Client, {groupchat, RoomJid}) ->
+    escalus_connection:send(Client, message_to_room(RoomJid)).
+
+message_to_room(RoomJid) ->
+    Timestamp = integer_to_binary(os:system_time(microsecond)),
+    escalus_stanza:groupchat_to(RoomJid, Timestamp).
+
+room_jid(RoomId, Domain) ->
+    <<(room_name(RoomId))/binary, $@, (muc_host(Domain))/binary>>.
+
+room_name(RoomId) ->
+    <<"room_", (integer_to_binary(RoomId))/binary>>.
+
+muc_host(Domain) ->
+    <<"muclight.", Domain/binary>>.
+
+ns(muc_light_create) -> <<"urn:xmpp:muclight:0#create">>;
+ns(muc_light_affiliations) -> <<"urn:xmpp:muclight:0#affiliations">>;
+ns(muc_light_configuration) -> <<"urn:xmpp:muclight:0#configuration">>.
+
+ttd(Stanza, #{recv_timestamp := Recv}) ->
+    SentBin = exml_query:path(Stanza, [{element, <<"body">>}, cdata]),
+    Recv - binary_to_integer(SentBin).
+
+%% User helpers
+
+-spec make_jid(amoc_scenario:user_id()) -> binary().
+make_jid(Id) ->
+    amoc_xmpp_users:make_jid(Id, dynamic_domains:domain_name(Id)).
+
+%% Stanza handlers
+
+sent_handler_spec() ->
+    [{fun is_muc_message/1,
+      fun() -> amoc_metrics:update_counter(muc_messages_sent) end} |
+     amoc_xmpp_presence:sent_handler_spec()].
+
+received_handler_spec() ->
+    [{fun is_muc_notification/1,
+      fun() -> amoc_metrics:update_counter(muc_notifications_received) end},
+     {fun is_muc_message/1,
+      fun(_, Stanza, Metadata) ->
+              amoc_metrics:update_counter(muc_messages_received),
+              amoc_metrics:update_time(message_ttd, ttd(Stanza, Metadata))
+      end} |
+     amoc_xmpp_presence:received_handler_spec()].
+
+is_muc_notification(Message = #xmlel{name = <<"message">>}) ->
+    exml_query:attr(Message, <<"type">>) =:= <<"groupchat">>
+        andalso lists:member(exml_query:path(Message, [{element, <<"x">>}, {attr, <<"xmlns">>}]),
+                             [ns(muc_light_affiliations),
+                              ns(muc_light_configuration)]);
+is_muc_notification(_) -> false.
+
+is_muc_message(Stanza = #xmlel{name = <<"message">>}) ->
+    exml_query:attr(Stanza, <<"type">>) =:= <<"groupchat">>;
+is_muc_message(_) -> false.
+
+%% Config helpers
+
+cfg(Name) ->
+    convert(Name, amoc_config:get(Name)).
+
+convert(room_creation_interval, V) -> timer:seconds(V);
+convert(room_message_interval, V) -> timer:seconds(V);
+convert(delay_before_sending_messages, V) -> timer:seconds(V);
+convert(_Name, V) -> V.

--- a/src/scenarios/dynamic_domains_muc_light.erl
+++ b/src/scenarios/dynamic_domains_muc_light.erl
@@ -6,7 +6,7 @@
 -define(V(X), (fun amoc_config_validation:X/1)).
 
 -required_variable(
-   [#{name => messages_sent_per_room, default_value => 180, verification => ?V(nonnegative_integer),
+   [#{name => messages_sent_per_room, default_value => 60, verification => ?V(nonnegative_integer),
       description => "Number of messages sent per room"},
     #{name => room_creation_interval, default_value => 20, verification => ?V(nonnegative_integer),
       description => "Delay between creating consecutive rooms (in seconds)"},

--- a/src/scenarios/dynamic_domains_muc_light.erl
+++ b/src/scenarios/dynamic_domains_muc_light.erl
@@ -23,6 +23,7 @@
 -spec init() -> ok.
 init() ->
     ?LOG_INFO("init metrics"),
+    dynamic_domains:init(),
     amoc_xmpp_presence:init(),
     amoc_metrics:init(counters, muc_rooms_created),
     amoc_metrics:init(counters, muc_occupants),

--- a/src/scenarios/dynamic_domains_pm.erl
+++ b/src/scenarios/dynamic_domains_pm.erl
@@ -5,7 +5,7 @@
 -define(V(X), (fun amoc_config_validation:X/1)).
 
 -required_variable(
-   [#{name => message_count, default_value => 60, verification => ?V(positive_integer),
+   [#{name => message_count, default_value => 60, verification => ?V(nonnegative_integer),
       description => "Number of messages sent by each user"},
     #{name => message_interval, default_value => 10, verification => ?V(nonnegative_integer),
       description => "Interval (in seconds) between messages"}

--- a/src/scenarios/dynamic_domains_pm.erl
+++ b/src/scenarios/dynamic_domains_pm.erl
@@ -1,0 +1,76 @@
+-module(dynamic_domains_pm).
+
+-include_lib("kernel/include/logger.hrl").
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-required_variable(
+   [#{name => message_count, default_value => 60, verification => ?V(positive_integer),
+      description => "Number of messages sent by each user"},
+    #{name => message_interval, default_value => 10, verification => ?V(nonnegative_integer),
+      description => "Interval (in seconds) between messages"}
+   ]).
+
+-behaviour(amoc_scenario).
+
+-export([init/0, start/1]).
+
+-spec init() -> ok.
+init() ->
+    ?LOG_INFO("init metrics"),
+    amoc_xmpp_presence:init(),
+    amoc_metrics:init(counters, messages_sent),
+    amoc_metrics:init(counters, messages_received),
+    amoc_metrics:init(times, message_ttd),
+    ok.
+
+-spec start(amoc_scenario:user_id()) -> any().
+start(MyId) ->
+    Spec = amoc_xmpp_handlers:make_props(received_handler_spec(), sent_handler_spec()),
+    {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
+    amoc_xmpp_presence:start(Client),
+    do(MyId, Client),
+    amoc_xmpp_presence:stop(Client).
+
+-record(state, {neighbours}).
+
+-spec do(amoc_scenario:user_id(), escalus:client()) -> any().
+do(MyId, Client) ->
+    NeighbourIds = amoc_xmpp:bucket_neighbours(MyId, 10),
+    TimeTable = timetable:new(chat, cfg(message_count), cfg(message_interval)),
+    timetable:do(Client, fun send_stanza/3, TimeTable, #state{neighbours = NeighbourIds}).
+
+%% One-to-one messages
+
+send_stanza(Client, chat, State = #state{neighbours = [RecipientId | Rest]}) ->
+    Msg = escalus_stanza:chat_to_with_id_and_timestamp(make_jid(RecipientId), <<"hello">>),
+    escalus_connection:send(Client, Msg),
+    State#state{neighbours = Rest ++ [RecipientId]}.
+
+%% User helpers
+
+-spec make_jid(amoc_scenario:user_id()) -> binary().
+make_jid(Id) ->
+    amoc_xmpp_users:make_jid(Id, dynamic_domains:domain_name(Id)).
+
+%% Stanza handlers
+
+sent_handler_spec() ->
+    [{fun escalus_pred:is_chat_message/1, fun amoc_xmpp_handlers:measure_sent_messages/0} |
+     amoc_xmpp_presence:sent_handler_spec()].
+
+received_handler_spec() ->
+    [{fun escalus_pred:is_chat_message/1, fun handle_chat_message/3} |
+     amoc_xmpp_presence:received_handler_spec()].
+
+handle_chat_message(Client, Stanza, Metadata) ->
+    amoc_metrics:update_counter(messages_received),
+    amoc_xmpp_handlers:measure_ttd(Client, Stanza, Metadata).
+
+%% Config helpers
+
+cfg(Name) ->
+    convert(Name, amoc_config:get(Name)).
+
+convert(message_interval, V) -> timer:seconds(V);
+convert(_Name, V) -> V.

--- a/src/scenarios/dynamic_domains_pm.erl
+++ b/src/scenarios/dynamic_domains_pm.erl
@@ -33,7 +33,7 @@ start(MyId) ->
     do(MyId, Client),
     amoc_xmpp_presence:stop(Client).
 
--record(state, {neighbours}).
+-record(state, {neighbours :: [amoc_scenario:user_id()]}).
 
 -spec do(amoc_scenario:user_id(), escalus:client()) -> any().
 do(MyId, Client) ->
@@ -43,6 +43,7 @@ do(MyId, Client) ->
 
 %% One-to-one messages
 
+-spec send_stanza(escalus:client(), chat, #state{}) -> #state{}.
 send_stanza(Client, chat, State = #state{neighbours = [RecipientId | Rest]}) ->
     Msg = escalus_stanza:chat_to_with_id_and_timestamp(make_jid(RecipientId), <<"hello">>),
     escalus_connection:send(Client, Msg),

--- a/src/scenarios/dynamic_domains_pm.erl
+++ b/src/scenarios/dynamic_domains_pm.erl
@@ -18,6 +18,7 @@
 -spec init() -> ok.
 init() ->
     ?LOG_INFO("init metrics"),
+    dynamic_domains:init(),
     amoc_xmpp_presence:init(),
     amoc_metrics:init(counters, messages_sent),
     amoc_metrics:init(counters, messages_received),


### PR DESCRIPTION
New XMPP helpers:
- `amoc_xmpp_muc` supports MUC Light room creation and has configuration options.
- `amoc_xmpp` supports "bucket neighbours" where users are distributed into evenly sized buckets (10 by default), what makes expected metrics like message count predictable and verifiable.
- `amoc_xmpp_presence` is a new module for sending (un)available presences with metrics and optional waiting before/after the presences.
- `amoc_xmpp_mam` is a new module for sending MAM lookup requests, which cyclically page through the results. There are metrics as well.

New general helpers:
- `timetable` allows to easily schedule time-based actions without having to create an event loop and relying on message order, which can be unpredicatable.
- `dynamic_domains` supports optional domain creation and assigns domains to users, grouping them into configurable buckets.

New scenarios:
- `dynamic_domains_pm` - one-to-one messaging
- `dynamic_domains_mam_lookup` - MAM lookup, needs archive and domains from `dynamic_domains_pm`
- `dynamic_domains_muc_light` - MUC Light messaging
- `dynamic_domains_mam_muc_lookup` - MAM MUC lookup, needs archive and domains from `dynamic_domains_muc_light`

TO DO, will be done separately:
- Scenario for inbox
- Some functionality could be moved to Amoc (e.g. timetable) or Escalus (predicates, stanza manipulation)
- Unit tests? So far all scenarios are being used in the load tests in the AWS infrastructure
- Rework other scenarios using the new modules and helpers

Another useful change would be to set the stanza handlers dynamically, which could detect stanzas received when they are not expected, e.g. archived messages after the "fin" element. This would require a small change in Escalus. It is a minor issue anyway.