### PR TITLE
Build multi-platform docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,48 +1,73 @@
- name: CI
+name: CI
 
- # Controls when the action will run.
- on:
-   # Triggers the workflow on push or pull request events but only for the master branch
-   push:
-     branches: [ master ]
-   pull_request:
-     branches: [ master ]
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
- jobs:
-   test:
-     name: OTP ${{matrix.otp}}
-     strategy:
-       matrix:
-         otp: ['24.0', '23.3.1']
-     runs-on: 'ubuntu-20.04'
-     steps:
-       - uses: actions/checkout@v2
-         with:
-           fetch-depth: 0
-       - uses: erlef/setup-beam@v1
-         with:
-           otp-version: ${{ matrix.otp }}
-           rebar3-version: '3.16.1'
-       - name: Compile project
-         run: rebar3 compile
-       - name: run xref check
-         run: rebar3 xref
-       - name: run dialyzer check
-         run: rebar3 dialyzer
+jobs:
+  test:
+    name: OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        otp: ['25.3', '24.3.4.9']
+    runs-on: 'ubuntu-22.04'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          rebar3-version: '3.16.1'
+      - name: Compile project
+        run: rebar3 compile
+      - name: run xref check
+        run: rebar3 xref
+      - name: run dialyzer check
+        run: rebar3 dialyzer
 
-   integration_test:
-     name: docker container test with OTP ${{matrix.otp}}
-     strategy:
-       matrix:
-         otp: ['24.0', '23.3.1']
-     runs-on: 'ubuntu-20.04'
-     env:
-       OTP_RELEASE: ${{ matrix.otp }}
-     steps:
-       - uses: actions/checkout@v2
-         with:
-           fetch-depth: 0
-       - name: build docker image
-         run: ./ci/build_docker_image.sh
-       - name: test docker image
-         run: ./ci/test_docker_image.sh
+  integration_test:
+    name: docker container test with OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        otp: ['25.3', '24.3.4.9']
+    runs-on: 'ubuntu-22.04'
+    env:
+      OTP_RELEASE: ${{ matrix.otp }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: build docker image
+        run: ./ci/build_docker_image.sh
+      - name: test docker image
+        run: ./ci/test_docker_image.sh
+
+  docker_image:
+    name: build and push multi-platform docker image
+    runs-on: 'ubuntu-22.04'
+    needs:
+      - test
+      - integration_test
+#    if: github.ref == 'refs/heads/master'
+    env:
+      OTP_RELEASE: 25.3
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+      - name: build multi-platform docker image
+        run: ./ci/build_and_push_docker_image.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     needs:
       - test
       - integration_test
-#    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     env:
       OTP_RELEASE: 25.3
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
-FROM phusion/baseimage:focal-1.0.0 as builder
+ARG otp_vsn
+FROM erlang:${otp_vsn} as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y git g++ make openssl libssl-dev gnupg2 wget
 
-ARG otp_vsn=24.0-1
-
-RUN wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
-    dpkg -i erlang-solutions_2.0_all.deb && \
-    apt-get update && \
-    apt-get install -y esl-erlang=1:${otp_vsn}
-
-ARG REBAR3_VERSION="3.16.1"
+ARG REBAR3_VERSION="3.20.0"
 RUN set -xe \
     && REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/releases/download/${REBAR3_VERSION}/rebar3" \
     && curl -fSL -o rebar3 "$REBAR3_DOWNLOAD_URL" \
@@ -27,16 +21,12 @@ MAINTAINER Erlang Solutions <mongoose-im@erlang-solutions.com>
 
 RUN useradd -ms /bin/bash amoc
 
+USER amoc
+
 ARG amoc_arsenal_home=/home/amoc/amoc_arsenal_xmpp
 RUN mkdir ${amoc_arsenal_home}
 COPY --from=builder amoc_arsenal_build/_build/default/rel/amoc_arsenal_xmpp/ ${amoc_arsenal_home}
-RUN chown -R amoc:amoc ${amoc_arsenal_home}
-
-RUN mkdir /etc/service/amoc
-## this env is required for amoc.sh script
-ENV EXEC_PATH ${amoc_arsenal_home}/bin/amoc_arsenal_xmpp
-COPY --from=builder amoc_arsenal_build/_build/default/lib/amoc/docker/amoc.sh /etc/service/amoc/run
 
 EXPOSE 4000
 
-CMD ["/sbin/my_init"]
+CMD ["/home/amoc/amoc_arsenal_xmpp/bin/amoc_arsenal_xmpp", "console", "-noshell", "-noinput", "+Bd"]

--- a/ci/build_and_push_docker_image.sh
+++ b/ci/build_and_push_docker_image.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export otp_vsn="${OTP_RELEASE:-25.3}"
+echo "ERLANG/OTP ${otp_vsn}"
+
+docker buildx build --platform linux/amd64,linux/arm64 \
+       --build-arg otp_vsn \
+       --push -t mongooseim/amoc-arsenal-xmpp:latest .

--- a/ci/build_docker_image.sh
+++ b/ci/build_docker_image.sh
@@ -2,7 +2,7 @@
 
 # Get current repo version
 version="$(git rev-parse --short HEAD)"
-otp_vsn="${OTP_RELEASE:-24.0}-1"
+otp_vsn="${OTP_RELEASE:-25.3}"
 echo "ERLANG/OTP ${otp_vsn}"
 echo "AMOC-ARSENAL-XMPP ${version}"
 


### PR DESCRIPTION
Build and push multi-platform docker images
- Support `arm64` in `Dockerfile` (requires a different base image)
- Add a job for building and pushing the images
- Update versions (OTP, rebar etc.)