### PR TITLE
Fix predefined metrics

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 ]}.
 
 { deps, [
-    {amoc_arsenal, {git, "https://github.com/esl/amoc-arsenal.git", {branch, "main"}}},
+    {amoc_arsenal, {git, "https://github.com/esl/amoc-arsenal.git", {branch, "stable"}}},
     {escalus, "4.2.16"},
     {jiffy, "1.1.2"},
     {fusco, "0.1.1"}

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"amoc">>,{pkg,<<"amoc">>,<<"3.3.0">>},1},
  {<<"amoc_arsenal">>,
   {git,"https://github.com/esl/amoc-arsenal.git",
-       {ref,"b6dc37c3c7b8ad439c87483939c91f784fd51d50"}},
+       {ref,"a0a4115f8595e20f4b454b67f66beca60580aafd"}},
   0},
  {<<"amoc_rest">>,
   {git,"https://github.com/esl/amoc_rest.git",

--- a/rel/app.config
+++ b/rel/app.config
@@ -1,5 +1,4 @@
 %% -*-erlang-*-
-
 [
     {kernel, [
         {logger,
@@ -13,6 +12,11 @@
                formatter => {logger_formatter, #{template => [time, " [", level, "] ", msg, "\n"]}}
            }}
          ]}]},
-    {ssl, [{session_cb, amoc_always_null_ssl_session_cache}]}
-]   .
-
+    {ssl, [{session_cb, amoc_always_null_ssl_session_cache}]},
+    {amoc_arsenal,
+     [{predefined_metrics, [{times, connection},
+                            {counters, connections},
+                            {counters, connection_retries},
+                            {counters, connection_failures}]}
+     ]}
+].


### PR DESCRIPTION
> When load-testing TLS, I found that the predefined connection metrics are missing in amoc_arsenal. To fix this, add the metrics to app.config in amoc-arsenal-xmpp:
> ```erlang
>    {amoc_arsenal,
>     [{predefined_metrics, [{times, connection},
>                            {counters, connections},
>                            {counters, connection_retries},
>                            {counters, connection_failures}]}
>     ]}
> ```
>
> Also, fix the calls to application:get_application(?MODULE) in amoc-arsenal:
> ```erlang
> {ok, App} = application:get_application(?MODULE)
> ```
>
> Verify in a load test, that the metrics are working.