### PR TITLE
Don't initialize amoc_xmpp_presence twice (in helper and scenario)

### DIFF
--- a/src/helpers/amoc_xmpp_inbox.erl
+++ b/src/helpers/amoc_xmpp_inbox.erl
@@ -15,7 +15,6 @@
 
 -spec init() -> ok.
 init() ->
-    amoc_xmpp_presence:init(),
     amoc_metrics:init(counters, inbox_lookups),
     amoc_metrics:init(counters, inbox_messages_received),
     amoc_metrics:init(counters, timeouts),

--- a/src/helpers/amoc_xmpp_mam.erl
+++ b/src/helpers/amoc_xmpp_mam.erl
@@ -20,7 +20,6 @@
 
 -spec init() -> ok.
 init() ->
-    amoc_xmpp_presence:init(),
     amoc_metrics:init(counters, mam_lookups),
     amoc_metrics:init(counters, mam_messages_received),
     amoc_metrics:init(counters, timeouts),


### PR DESCRIPTION
Prometheus raises an error `mf_already_exists` if you try to run the `dynamic_domains_mam_lookup` or `dynamic_domains_inbox_lookup` scenario.

Exometer didn't complain, so this duplicate init was unnoticed.