### PR TITLE
Use `amoc_users_size` metric

### DIFF
--- a/rel/app.config
+++ b/rel/app.config
@@ -17,6 +17,7 @@
      [{predefined_metrics, [{times, connection},
                             {counters, connections},
                             {counters, connection_retries},
-                            {counters, connection_failures}]}
+                            {counters, connection_failures},
+                            {gauge, amoc_users_size}]}
      ]}
 ].

--- a/src/amoc_arsenal_xmpp.app.src
+++ b/src/amoc_arsenal_xmpp.app.src
@@ -14,7 +14,8 @@
    {predefined_metrics, [{times, connection},
                          {counters, connections},
                          {counters, connection_retries},
-                         {counters, connection_failures}]}
+                         {counters, connection_failures},
+                         {gauge, amoc_users_size}]}
   ]},
   {modules, []},
 

--- a/src/scenarios/dynamic_domains_inbox_lookup.erl
+++ b/src/scenarios/dynamic_domains_inbox_lookup.erl
@@ -44,7 +44,7 @@ start(MyId) ->
     {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec, #{create_domain => false}),
     amoc_xmpp_presence:start(Client),
     do(MyId, Client),
-    amoc_xmpp_presence:stop(Client).
+    amoc_xmpp:stop_presence_connection(Client).
 
 -spec do(amoc_scenario:user_id(), escalus:client()) -> any().
 do(_MyId, Client) ->

--- a/src/scenarios/dynamic_domains_mam_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_lookup.erl
@@ -45,7 +45,7 @@ start(MyId) ->
     {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec, #{create_domain => false}),
     amoc_xmpp_presence:start(Client),
     do(MyId, Client),
-    amoc_xmpp_presence:stop(Client).
+    amoc_xmpp:stop_presence_connection(Client).
 
 -record(state, {last_mam_id = none :: amoc_xmpp_mam:last_id()}).
 

--- a/src/scenarios/dynamic_domains_mam_muc_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_muc_lookup.erl
@@ -49,7 +49,7 @@ start(MyId) ->
     {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec, #{create_domain => false}),
     amoc_xmpp_presence:start(Client),
     do(MyId, Client),
-    amoc_xmpp_presence:stop(Client).
+    amoc_xmpp:stop_presence_connection(Client).
 
 -spec do(amoc_scenario:user_id(), escalus:client()) -> any().
 do(MyId, Client) ->

--- a/src/scenarios/dynamic_domains_muc_light.erl
+++ b/src/scenarios/dynamic_domains_muc_light.erl
@@ -54,7 +54,7 @@ start(MyId) ->
     {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
     amoc_xmpp_presence:start(Client),
     do(MyId, Client),
-    amoc_xmpp_presence:stop(Client).
+    amoc_xmpp:stop_presence_connection(Client).
 
 -spec do(amoc_scenario:user_id(), escalus:client()) -> any().
 do(MyId, Client) ->

--- a/src/scenarios/dynamic_domains_pm.erl
+++ b/src/scenarios/dynamic_domains_pm.erl
@@ -45,7 +45,7 @@ start(MyId) ->
     {ok, Client, _} = dynamic_domains:connect_or_exit(MyId, Spec),
     amoc_xmpp_presence:start(Client),
     do(MyId, Client),
-    amoc_xmpp_presence:stop(Client).
+    amoc_xmpp:stop_presence_connection(Client).
 
 -record(state, {neighbours :: [amoc_scenario:user_id()]}).
 

--- a/src/scenarios/mongoose_in_band_registration.erl
+++ b/src/scenarios/mongoose_in_band_registration.erl
@@ -45,6 +45,7 @@ start(MyId) ->
     maybe_register(Cfg),
 
     {ok, Client, _} = escalus_connection:start(Cfg),
+    amoc_metrics:update_gauge(amoc_users_size, amoc_users_sup:count_no_of_users()),
 
     %%Allow presence stanza only
     AllowPresence = fun escalus_pred:is_presence/1,
@@ -63,7 +64,7 @@ start(MyId) ->
 
     timer:sleep(10000),
     escalus_session:send_presence_unavailable(Client),
-    escalus_connection:stop(Client).
+    amoc_xmpp:stop_connection(Client).
 
 -spec maybe_register(escalus_users:user_spec()) -> ok | already_registered.
 maybe_register(Cfg) ->

--- a/src/scenarios/mongoose_mam.erl
+++ b/src/scenarios/mongoose_mam.erl
@@ -126,7 +126,7 @@ start(MyId) ->
 
     timer:sleep(?SLEEP_TIME_AFTER_SCENARIO),
     escalus_session:send_presence_unavailable(Client),
-    escalus_connection:stop(Client),
+    amoc_xmpp:stop_connection(Client),
     ok.
 
 session_indicator(MyId, MAMReader) when MyId rem MAMReader == 0 ->

--- a/src/scenarios/mongoose_one_to_one.erl
+++ b/src/scenarios/mongoose_one_to_one.erl
@@ -82,7 +82,7 @@ start(MyId) ->
 
     escalus_connection:wait(Client, ?SLEEP_TIME_AFTER_SCENARIO),
     escalus_session:send_presence_unavailable(Client),
-    escalus_connection:stop(Client).
+    amoc_xmpp:stop_connection(Client).
 
 -spec do(amoc_scenario:user_id(), escalus:client()) -> any().
 do(MyId, Client) ->

--- a/src/scenarios/mongoose_ssl_tcp_ws_bosh.erl
+++ b/src/scenarios/mongoose_ssl_tcp_ws_bosh.erl
@@ -44,7 +44,7 @@ start(MyId) ->
 
     timer:sleep(10*1000),
     escalus_session:send_presence_unavailable(Client),
-    escalus_connection:stop(Client).
+    amoc_xmpp:stop_connection(Client).
 
 -spec send_messages_many_times(escalus:client(), timeout(), [amoc_scenario:user_id()]) -> ok.
 send_messages_many_times(Client, MessageInterval, NeighbourIds) ->

--- a/src/scenarios/pubsub_pep.erl
+++ b/src/scenarios/pubsub_pep.erl
@@ -199,8 +199,10 @@ user_loop(Client) ->
             iq_metrics:request(publication, Id, IqTimeout),
             user_loop(Client);
         {'DOWN', _, process, Pid, Info} when Pid =:= Client#client.rcv_pid ->
+            amoc_metrics:update_gauge(amoc_users_size, amoc_users_sup:count_no_of_users()),
             ?LOG_ERROR("TCP connection process ~p down: ~p", [Pid, Info]);
         Msg ->
+            amoc_metrics:update_gauge(amoc_users_size, amoc_users_sup:count_no_of_users()),
             ?LOG_ERROR("unexpected message ~p", [Msg])
     end.
 

--- a/src/scenarios/pubsub_simple.erl
+++ b/src/scenarios/pubsub_simple.erl
@@ -232,8 +232,10 @@ user_loop(Client, Node, Requests) ->
             amoc_metrics:update_counter(publication_query, 1),
             user_loop(Client, Node, Requests#{Id=>{new, TS}});
         {'DOWN', _, process, Pid, Info} when Pid =:= Client#client.rcv_pid ->
+            amoc_metrics:update_gauge(amoc_users_size, amoc_users_sup:count_no_of_users()),
             ?LOG_ERROR("TCP connection process ~p down: ~p", [Pid, Info]);
         Msg ->
+            amoc_metrics:update_gauge(amoc_users_size, amoc_users_sup:count_no_of_users()),
             ?LOG_ERROR("unexpected message ~p", [Msg])
     after IqTimeout ->
         user_loop(Client, Node, verify_request(Requests))

--- a/src/scenarios/simple_rest_api.erl
+++ b/src/scenarios/simple_rest_api.erl
@@ -54,7 +54,7 @@ do_start(xmpp, MyId) ->
 
     escalus_connection:wait_forever(Client),
 
-    escalus_connection:stop(Client).
+    amoc_xmpp:stop_connection(Client).
 
 log_message(_Client, Stanza) ->
     ?LOG_WARNING("~p", [Stanza]),


### PR DESCRIPTION
This PR adds the `amoc_users_size` gauge to the `predefined_metrics` section in both `amoc_arsenal_xmpp.app` and `app.config`.

The metric was already defined in the `amoc_arsenal` repository [here](https://github.com/esl/amoc-arsenal/blob/main/src/amoc_metrics.erl#L52-L58), but it wasn't included in the configuration used during scenarios. This could cause confusion, as the metric appeared to be predefined and expected to be present, but it wasn’t actually available.

With this update, the metric is now properly configured and should work as expected during scenario runs.
