### PR TITLE
Prevent duplicate console logs

### DIFF
--- a/rel/app.config
+++ b/rel/app.config
@@ -2,7 +2,7 @@
 [
     {kernel, [
         {logger,
-         [{handler, log_to_console, logger_std_h,
+         [{handler, default, logger_std_h,
            #{
                formatter => {logger_formatter, #{template => [time, " [", level, "] ", msg, "\n"]}}
            }},


### PR DESCRIPTION
There were two handlers for console logging:
  - `default` (provided by logger)
  - `log_to_console` (custom, provided in `app.config`)

As a result, all console logs were duplicated.
To fix this, the custom handler needs to be called `default`, replacing the original one.

I checked manually that the issue is gone. The same solution is already working for [MongooseIM](https://github.com/esl/MongooseIM/blob/master/rel/files/app.config#L25).