### PR TITLE
Don't hide presence errors

### DIFF
--- a/src/helpers/amoc_xmpp_presence.erl
+++ b/src/helpers/amoc_xmpp_presence.erl
@@ -65,13 +65,19 @@ send_presence_unavailable(Client) ->
 
 -spec sent_handler_spec() -> [amoc_xmpp_handlers:handler_spec()].
 sent_handler_spec() ->
-    [{fun escalus_pred:is_presence/1,
+    [{fun is_presence_without_error/1,
       fun() -> amoc_metrics:update_counter(presences_sent) end}].
 
 -spec received_handler_spec() -> [amoc_xmpp_handlers:handler_spec()].
 received_handler_spec() ->
-    [{fun escalus_pred:is_presence/1,
+    [{fun is_presence_without_error/1,
       fun() -> amoc_metrics:update_counter(presences_received) end}].
+
+%% Predicates
+
+-spec is_presence_without_error(exmle:element()) -> boolean().
+is_presence_without_error(Stanza) ->
+    escalus_pred:is_presence(Stanza) andalso exml_query:attr(Stanza, <<"type">>) =/= <<"error">>.
 
 %% Config helpers
 


### PR DESCRIPTION
Previously, the presence stanza handlers would silently consume all presences including errors.

It is much better to treat errors as unexpected stanzas instead of counting them as "just presences",
which would give a false impression of normal operation.

Tested manually for a case when presence errors were occurring (an error in configuration).