### PR TITLE
Respond to ping requests from the server

### DIFF
--- a/src/helpers/amoc_xmpp_ping.erl
+++ b/src/helpers/amoc_xmpp_ping.erl
@@ -1,0 +1,46 @@
+%%% @doc This module handles server ping requests (XEP-0199, section 4.1)
+-module(amoc_xmpp_ping).
+
+-define(V(X), (fun amoc_config_validation:X/1)).
+
+-include_lib("escalus/include/escalus_xmlns.hrl").
+
+-required_variable(
+   [#{name => ping_enabled,
+      default_value => true,
+      verification => ?V(boolean),
+      description => "Enables responding to ping requests from the server"}
+   ]).
+
+-export([init/0,
+         sent_handler_spec/0,
+         received_handler_spec/0]).
+
+%%% API
+
+-spec init() -> ok.
+init() ->
+    amoc_metrics:init(counters, iq_ping_sent),
+    amoc_metrics:init(counters, iq_ping_received),
+    ok.
+
+-spec sent_handler_spec() -> [amoc_xmpp_handlers:handler_spec()].
+sent_handler_spec() ->
+    [{fun(Stanza) -> escalus_pred:is_iq_result(Stanza) andalso is_ping(Stanza) end,
+      fun() -> amoc_metrics:update_counter(iq_ping_sent) end}].
+
+-spec received_handler_spec() -> [amoc_xmpp_handlers:handler_spec()].
+received_handler_spec() ->
+    [{fun(Stanza) -> escalus_pred:is_iq_get(Stanza) andalso is_ping(Stanza) end,
+      fun respond_to_ping/2}].
+
+%%% Helpers
+
+-spec is_ping(exml:element()) -> boolean().
+is_ping(Stanza) ->
+    ?NS_PING =:= exml_query:path(Stanza, [{element, <<"ping">>}, {attr, <<"xmlns">>}]).
+
+-spec respond_to_ping(escalus:client(), exml:element()) -> ok.
+respond_to_ping(Client, Request) ->
+    amoc_metrics:update_counter(iq_ping_received),
+    escalus:send(Client, escalus_stanza:iq_result(Request)).

--- a/src/helpers/amoc_xmpp_presence.erl
+++ b/src/helpers/amoc_xmpp_presence.erl
@@ -75,7 +75,7 @@ received_handler_spec() ->
 
 %% Predicates
 
--spec is_presence_without_error(exmle:element()) -> boolean().
+-spec is_presence_without_error(exml:element()) -> boolean().
 is_presence_without_error(Stanza) ->
     escalus_pred:is_presence(Stanza) andalso exml_query:attr(Stanza, <<"type">>) =/= <<"error">>.
 

--- a/src/scenarios/dynamic_domains_inbox_lookup.erl
+++ b/src/scenarios/dynamic_domains_inbox_lookup.erl
@@ -33,6 +33,7 @@ init() ->
     ?LOG_INFO("init metrics"),
     dynamic_domains:init(),
     amoc_xmpp_presence:init(),
+    amoc_xmpp_ping:init(),
     amoc_xmpp_inbox:init(),
     ok.
 
@@ -58,10 +59,11 @@ lookup(Client, inbox_lookup) ->
 %% Stanza handlers
 
 sent_handler_spec() ->
-    amoc_xmpp_presence:sent_handler_spec().
+    amoc_xmpp_presence:sent_handler_spec() ++ amoc_xmpp_ping:sent_handler_spec().
 
 received_handler_spec() ->
-    amoc_xmpp_inbox:received_handler_spec() ++ amoc_xmpp_presence:received_handler_spec().
+    amoc_xmpp_inbox:received_handler_spec() ++ amoc_xmpp_presence:received_handler_spec() ++
+        amoc_xmpp_ping:received_handler_spec().
 
 %% Config helpers
 

--- a/src/scenarios/dynamic_domains_mam_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_lookup.erl
@@ -34,6 +34,7 @@ init() ->
     ?LOG_INFO("init metrics"),
     dynamic_domains:init(),
     amoc_xmpp_presence:init(),
+    amoc_xmpp_ping:init(),
     amoc_xmpp_mam:init(),
     ok.
 
@@ -62,10 +63,11 @@ send_stanza(Client, mam_lookup, State = #state{last_mam_id = Id}) ->
 %% Stanza handlers
 
 sent_handler_spec() ->
-    amoc_xmpp_presence:sent_handler_spec().
+    amoc_xmpp_presence:sent_handler_spec() ++ amoc_xmpp_ping:sent_handler_spec().
 
 received_handler_spec() ->
-    amoc_xmpp_mam:received_handler_spec(chat) ++ amoc_xmpp_presence:received_handler_spec().
+    amoc_xmpp_mam:received_handler_spec(chat) ++ amoc_xmpp_presence:received_handler_spec() ++
+        amoc_xmpp_ping:received_handler_spec().
 
 %% Config helpers
 

--- a/src/scenarios/dynamic_domains_mam_muc_lookup.erl
+++ b/src/scenarios/dynamic_domains_mam_muc_lookup.erl
@@ -38,6 +38,7 @@ init() ->
     ?LOG_INFO("init metrics"),
     dynamic_domains:init(),
     amoc_xmpp_presence:init(),
+    amoc_xmpp_ping:init(),
     amoc_xmpp_mam:init(),
     ok.
 
@@ -89,10 +90,11 @@ muc_host(Domain) ->
 %% Stanza handlers
 
 sent_handler_spec() ->
-    amoc_xmpp_presence:sent_handler_spec().
+    amoc_xmpp_presence:sent_handler_spec() ++ amoc_xmpp_ping:sent_handler_spec().
 
 received_handler_spec() ->
-    amoc_xmpp_mam:received_handler_spec(groupchat) ++ amoc_xmpp_presence:received_handler_spec().
+    amoc_xmpp_mam:received_handler_spec(groupchat) ++ amoc_xmpp_presence:received_handler_spec() ++
+        amoc_xmpp_ping:received_handler_spec().
 
 %% Config helpers
 

--- a/src/scenarios/dynamic_domains_muc_light.erl
+++ b/src/scenarios/dynamic_domains_muc_light.erl
@@ -39,6 +39,7 @@ init() ->
     ?LOG_INFO("init metrics"),
     dynamic_domains:init(),
     amoc_xmpp_presence:init(),
+    amoc_xmpp_ping:init(),
     amoc_metrics:init(counters, muc_rooms_created),
     amoc_metrics:init(counters, muc_occupants),
     amoc_metrics:init(counters, muc_messages_sent),
@@ -136,7 +137,7 @@ make_jid(Id) ->
 sent_handler_spec() ->
     [{fun is_muc_message/1,
       fun() -> amoc_metrics:update_counter(muc_messages_sent) end} |
-     amoc_xmpp_presence:sent_handler_spec()].
+     amoc_xmpp_presence:sent_handler_spec() ++ amoc_xmpp_ping:sent_handler_spec()].
 
 received_handler_spec() ->
     [{fun is_muc_notification/1,
@@ -146,7 +147,7 @@ received_handler_spec() ->
               amoc_metrics:update_counter(muc_messages_received),
               amoc_metrics:update_time(message_ttd, ttd(Stanza, Metadata))
       end} |
-     amoc_xmpp_presence:received_handler_spec()].
+     amoc_xmpp_presence:received_handler_spec() ++ amoc_xmpp_ping:received_handler_spec()].
 
 is_muc_notification(Message = #xmlel{name = <<"message">>}) ->
     exml_query:attr(Message, <<"type">>) =:= <<"groupchat">>

--- a/src/scenarios/dynamic_domains_pm.erl
+++ b/src/scenarios/dynamic_domains_pm.erl
@@ -33,6 +33,7 @@ init() ->
     ?LOG_INFO("init metrics"),
     dynamic_domains:init(),
     amoc_xmpp_presence:init(),
+    amoc_xmpp_ping:init(),
     amoc_metrics:init(counters, messages_sent),
     amoc_metrics:init(counters, messages_received),
     amoc_metrics:init(counters, service_unavailable),
@@ -75,12 +76,12 @@ make_jid(Id) ->
 
 sent_handler_spec() ->
     [{fun escalus_pred:is_chat_message/1, fun amoc_xmpp_handlers:measure_sent_messages/0} |
-     amoc_xmpp_presence:sent_handler_spec()].
+     amoc_xmpp_presence:sent_handler_spec() ++ amoc_xmpp_ping:sent_handler_spec()].
 
 received_handler_spec() ->
     [{fun escalus_pred:is_chat_message/1, fun handle_chat_message/3},
      {fun is_service_unavailable/1, fun handle_service_unavailable/0} |
-     amoc_xmpp_presence:received_handler_spec()].
+     amoc_xmpp_presence:received_handler_spec() ++ amoc_xmpp_ping:received_handler_spec()].
 
 handle_chat_message(Client, Stanza, Metadata) ->
     amoc_metrics:update_counter(messages_received),


### PR DESCRIPTION
- Add helpers.
- Use them in the currently maintained scenarios.

To do for the future: mark unmaintained scenarios as such, e.g. by moving to an `outdated` directory.